### PR TITLE
Update mailparser dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   "dependencies": {
     "async": "^0.9.0",
     "imap": "~0.8.14",
-    "mailparser": "^0.4.8",
+    "mailparser": "^0.6.2",
     "mime": "^1.0.0"
   },
   "keywords": [


### PR DESCRIPTION
I get the following exception when parsing emails with pdf attachments:

```javascript
/email-application-api/node_modules/mailparser/lib/mailparser.js:1407
        defaultExt = mime.extension(contentType);
                          ^

TypeError: mime.extension is not a function
    at MailParser._generateFileName (/email-application-api/node_modules/mailparser/lib/mailparser.js:1407:27)
    at MailParser._processStateHeader (/email-application-api/node_modules/mailparser/lib/mailparser.js:309:61)
    at MailParser._process (/email-application-api/node_modules/mailparser/lib/mailparser.js:227:22)
    at runCallback (timers.js:781:20)
    at tryOnImmediate (timers.js:743:5)
    at processImmediate [as _immediateCallback] (timers.js:714:5)
```

Updating mailparser dependency to the latest minor version (0.6.2) fixes the problem.
